### PR TITLE
jarydo/Add Coordinates to User

### DIFF
--- a/backend/app/graphql/types.py
+++ b/backend/app/graphql/types.py
@@ -86,7 +86,6 @@ class UserInfoInput(graphene.InputObjectType):
     organization_address = graphene.String(required=True)
     organization_name = graphene.String(required=True)
     organization_desc = graphene.String(required=True)
-    organization_coordinates = graphene.List(graphene.Float)
     role = graphene.String(required=True)
     role_info = graphene.Field(RoleInfoInput)
     primary_contact = graphene.Field(ContactInput, required=True)

--- a/backend/app/graphql/types.py
+++ b/backend/app/graphql/types.py
@@ -85,7 +85,7 @@ class UserInfoInput(graphene.InputObjectType):
     organization_address = graphene.String(required=True)
     organization_name = graphene.String(required=True)
     organization_desc = graphene.String(required=True)
-    organization_coordinates = graphene.List(graphene.Float, required=True)
+    organization_coordinates = graphene.List(graphene.Float)
     role = graphene.String(required=True)
     role_info = graphene.Field(RoleInfoInput)
     primary_contact = graphene.Field(ContactInput, required=True)

--- a/backend/app/graphql/types.py
+++ b/backend/app/graphql/types.py
@@ -47,12 +47,12 @@ class RoleInfo(graphene.ObjectType):
     asp_info = graphene.Field(ASPInfo)
     donor_info = graphene.Field(DonorInfo)
 
-
 class UserInfo(graphene.ObjectType):
     email = graphene.String()
     organization_address = graphene.String()
     organization_name = graphene.String()
     organization_desc = graphene.String()
+    organization_coordinates = graphene.List(graphene.Float)
     role = graphene.String()
     role_info = graphene.Field(RoleInfo)
     primary_contact = graphene.Field(Contact)
@@ -85,6 +85,7 @@ class UserInfoInput(graphene.InputObjectType):
     organization_address = graphene.String(required=True)
     organization_name = graphene.String(required=True)
     organization_desc = graphene.String(required=True)
+    organization_coordinates = graphene.List(graphene.Float, required=True)
     role = graphene.String(required=True)
     role_info = graphene.Field(RoleInfoInput)
     primary_contact = graphene.Field(ContactInput, required=True)

--- a/backend/app/graphql/types.py
+++ b/backend/app/graphql/types.py
@@ -47,6 +47,7 @@ class RoleInfo(graphene.ObjectType):
     asp_info = graphene.Field(ASPInfo)
     donor_info = graphene.Field(DonorInfo)
 
+
 class UserInfo(graphene.ObjectType):
     email = graphene.String()
     organization_address = graphene.String()

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -5,7 +5,7 @@ from .user_info import UserInfo
 
 class User(mg.Document):
     auth_id = mg.StringField(required=True)
-    info = mg.EmbeddedDocumentField(UserInfo, required=True)
+    info: UserInfo = mg.EmbeddedDocumentField(UserInfo, required=True)
 
     def to_serializable_dict(self):
         """

--- a/backend/app/models/user_info.py
+++ b/backend/app/models/user_info.py
@@ -36,6 +36,7 @@ class UserInfo(mg.EmbeddedDocument):
     organization_address = mg.StringField(required=True)
     organization_name = mg.StringField(required=True)
     organization_desc = mg.StringField(required=True)
+    organization_coordinates = mg.GeoPointField(required=True)
     role = mg.StringField(choices=USERINFO_ROLES, required=True)
     role_info = mg.EmbeddedDocumentField(RoleInfo)
     primary_contact = mg.EmbeddedDocumentField(Contact, required=True)

--- a/backend/app/models/user_info.py
+++ b/backend/app/models/user_info.py
@@ -36,7 +36,7 @@ class UserInfo(mg.EmbeddedDocument):
     organization_address = mg.StringField(required=True)
     organization_name = mg.StringField(required=True)
     organization_desc = mg.StringField(required=True)
-    organization_coordinates = mg.GeoPointField(required=True)
+    organization_coordinates = mg.GeoPointField()
     role = mg.StringField(choices=USERINFO_ROLES, required=True)
     role_info = mg.EmbeddedDocumentField(RoleInfo)
     primary_contact = mg.EmbeddedDocumentField(Contact, required=True)

--- a/backend/app/resources/validate_utils.py
+++ b/backend/app/resources/validate_utils.py
@@ -54,7 +54,7 @@ def validate_coordinates(coordinates, error_list):
         error_list.append("The info.organization_coordinates supplied does not contain 2 elements.")
     elif not isinstance(coordinates[0], float) and not isinstance(coordinates[1], float):
         error_list.append("The info.organization_coordinates supplied does not contain a list of floats.")
-    elif -180 <= coordinates[0] <= 180 or -180 <= coordinates[1]<= 180:
+    elif not (-180 <= coordinates[0] <= 180) and not (-180 <= coordinates[1]<= 180):
         error_list.append("The info.organization_coordinates supplied are not in the interval [-180, 180].")
     return error_list
 

--- a/backend/app/resources/validate_utils.py
+++ b/backend/app/resources/validate_utils.py
@@ -64,7 +64,6 @@ def validate_userinfo(userinfo, error_list):
         "organization_address",
         "organization_name",
         "organization_desc",
-        "organization_coordinates",
         "role",
         "role_info",
         "primary_contact",

--- a/backend/app/resources/validate_utils.py
+++ b/backend/app/resources/validate_utils.py
@@ -47,6 +47,16 @@ def validate_role_info(role, role_info, role_info_str, error_list):
     # TODO: Add donor info validation once meal donor schema is finalized
     return error_list
 
+def validate_coordinates(coordinates, error_list):
+    if not isinstance(coordinates, list):
+        error_list.append("The info.organization_coordinates supplied is not a list.")
+    elif len(coordinates) != 2:
+        error_list.append("The info.organization_coordinates supplied does not contain 2 elements.")
+    elif not isinstance(coordinates[0], float) and not isinstance(coordinates[1], float):
+        error_list.append("The info.organization_coordinates supplied does not contain a list of floats.")
+    elif -180 <= coordinates[0] <= 180 or -180 <= coordinates[1]<= 180:
+        error_list.append("The info.organization_coordinates supplied are not in the interval [-180, 180].")
+    return error_list
 
 def validate_userinfo(userinfo, error_list):
     userinfo_fields = [
@@ -54,6 +64,7 @@ def validate_userinfo(userinfo, error_list):
         "organization_address",
         "organization_name",
         "organization_desc",
+        "organization_coordinates",
         "role",
         "role_info",
         "primary_contact",
@@ -86,6 +97,8 @@ def validate_userinfo(userinfo, error_list):
             )
         elif key == "active" and type(val) is not bool:
             error_list.append("The field info.active supplied is not a boolean.")
+        elif key == "organization_coordinates":
+            error_list = validate_coordinates(val, error_list)
         elif type(val) is not str and key != "active":
             error_list.append(f"The field info.{key} supplied is not a string.")
         elif val == "":

--- a/backend/app/resources/validate_utils.py
+++ b/backend/app/resources/validate_utils.py
@@ -59,11 +59,13 @@ def validate_coordinates(coordinates, error_list):
         coordinates[1], float
     ):
         error_list.append(
-            "The info.organization_coordinates supplied does not contain a list of floats."
+            "The info.organization_coordinates supplied"
+            " does not contain a list of floats."
         )
     elif not (-180 <= coordinates[0] <= 180) and not (-180 <= coordinates[1] <= 180):
         error_list.append(
-            "The info.organization_coordinates supplied are not in the interval [-180, 180]."
+            "The info.organization_coordinates supplied are not"
+            " in the interval [-180, 180]."
         )
     return error_list
 

--- a/backend/app/resources/validate_utils.py
+++ b/backend/app/resources/validate_utils.py
@@ -47,16 +47,26 @@ def validate_role_info(role, role_info, role_info_str, error_list):
     # TODO: Add donor info validation once meal donor schema is finalized
     return error_list
 
+
 def validate_coordinates(coordinates, error_list):
     if not isinstance(coordinates, list):
         error_list.append("The info.organization_coordinates supplied is not a list.")
     elif len(coordinates) != 2:
-        error_list.append("The info.organization_coordinates supplied does not contain 2 elements.")
-    elif not isinstance(coordinates[0], float) and not isinstance(coordinates[1], float):
-        error_list.append("The info.organization_coordinates supplied does not contain a list of floats.")
-    elif not (-180 <= coordinates[0] <= 180) and not (-180 <= coordinates[1]<= 180):
-        error_list.append("The info.organization_coordinates supplied are not in the interval [-180, 180].")
+        error_list.append(
+            "The info.organization_coordinates supplied does not contain 2 elements."
+        )
+    elif not isinstance(coordinates[0], float) and not isinstance(
+        coordinates[1], float
+    ):
+        error_list.append(
+            "The info.organization_coordinates supplied does not contain a list of floats."
+        )
+    elif not (-180 <= coordinates[0] <= 180) and not (-180 <= coordinates[1] <= 180):
+        error_list.append(
+            "The info.organization_coordinates supplied are not in the interval [-180, 180]."
+        )
     return error_list
+
 
 def validate_userinfo(userinfo, error_list):
     userinfo_fields = [

--- a/backend/app/services/implementations/onboarding_request_service.py
+++ b/backend/app/services/implementations/onboarding_request_service.py
@@ -1,3 +1,4 @@
+from ...utilities.location_to_coordinates import getGeocodeFromAddress
 from ...services.implementations.auth_service import AuthService
 from ..interfaces.onboarding_request_service import IOnboardingRequestService
 from ...models.onboarding_request import (
@@ -21,7 +22,7 @@ class OnboardingRequestService(IOnboardingRequestService):
         self.logger = logger
         self.email_service = email_service
 
-    def create_onboarding_request(self, userInfo):
+    def create_onboarding_request(self, userInfo: UserInfo):
         try:
             # Create initial UserInfo object
             user_info = UserInfo(
@@ -29,13 +30,16 @@ class OnboardingRequestService(IOnboardingRequestService):
                 organization_address=userInfo.organization_address,
                 organization_name=userInfo.organization_name,
                 organization_desc=userInfo.organization_desc,
-                organization_coordinates=userInfo.organization_coordinates,
+                organization_coordinates=getGeocodeFromAddress(
+                    userInfo.organization_address
+                ),
                 role=userInfo.role,
                 role_info=userInfo.role_info,
                 primary_contact=userInfo.primary_contact,
                 onsite_contacts=userInfo.onsite_contacts,
                 active=userInfo.active,
             )
+
             # Create OnboardingRequest object
             new_onboarding_request = OnboardingRequest(
                 info=user_info,

--- a/backend/app/services/implementations/onboarding_request_service.py
+++ b/backend/app/services/implementations/onboarding_request_service.py
@@ -29,6 +29,7 @@ class OnboardingRequestService(IOnboardingRequestService):
                 organization_address=userInfo.organization_address,
                 organization_name=userInfo.organization_name,
                 organization_desc=userInfo.organization_desc,
+                organization_coordinates=userInfo.organization_coordinates,
                 role=userInfo.role,
                 role_info=userInfo.role_info,
                 primary_contact=userInfo.primary_contact,

--- a/backend/app/services/implementations/user_service.py
+++ b/backend/app/services/implementations/user_service.py
@@ -178,12 +178,6 @@ class UserService(IUserService):
                     .first()
                     .info,
                 )
-
-                organization_coordinates = getGeocodeFromAddress(
-                    new_user.info.organization_address
-                )
-                new_user.info.organization_coordinates = organization_coordinates
-
                 new_user.save()
             except Exception as mongo_error:
                 # rollback user creation in Firebase

--- a/backend/app/services/implementations/user_service.py
+++ b/backend/app/services/implementations/user_service.py
@@ -176,9 +176,9 @@ class UserService(IUserService):
                     auth_id=firebase_user.uid,
                     info=OnboardingRequest.objects(id=create_user_dto.request_id)
                     .first()
-                    .info
+                    .info,
                 )
-                
+
                 organization_coordinates = getGeocodeFromAddress(
                     new_user.info.organization_address
                 )

--- a/backend/app/services/implementations/user_service.py
+++ b/backend/app/services/implementations/user_service.py
@@ -151,10 +151,12 @@ class UserService(IUserService):
                 raise e
 
         return user_dtos
-    
+
     def update_user_coordinates(self, user_dto):
         try:
-            organization_coordinates = getGeocodeFromAddress(user_dto.info.organization_address)
+            organization_coordinates = getGeocodeFromAddress(
+                user_dto.info.organization_address
+            )
             user_dto.info["organization_coordinates"] = organization_coordinates
             return user_dto
         except Exception as e:

--- a/backend/app/services/implementations/user_service.py
+++ b/backend/app/services/implementations/user_service.py
@@ -219,7 +219,6 @@ class UserService(IUserService):
     def update_user_by_id(self, user_id, update_user_dto):
         try:
             update_user_dto = self.update_user_coordinates(update_user_dto)
-            print(update_user_dto.info)
             old_user = User.objects(id=user_id).modify(
                 new=False,
                 auth_id=update_user_dto.auth_id,

--- a/backend/app/utilities/location_to_coordinates.py
+++ b/backend/app/utilities/location_to_coordinates.py
@@ -1,0 +1,17 @@
+import requests
+
+GEOCODE_API_URL="https://geocode.maps.co/search"
+
+def getGeocodeFromAddress(organization_address):
+    response = requests.get(
+        "{base_url}?q=\"{address}\"".format(
+            base_url=GEOCODE_API_URL, address=organization_address
+        )
+    )
+
+    response_json = response.json()
+
+    if len(response_json) == 0:
+        raise Exception("Failed to get coordinates from Geocode API")
+    
+    return [float(response_json[0]["lat"]), float(response_json[0]["lon"])]

--- a/backend/app/utilities/location_to_coordinates.py
+++ b/backend/app/utilities/location_to_coordinates.py
@@ -1,10 +1,11 @@
 import requests
 
-GEOCODE_API_URL="https://geocode.maps.co/search"
+GEOCODE_API_URL = "https://geocode.maps.co/search"
+
 
 def getGeocodeFromAddress(organization_address):
     response = requests.get(
-        "{base_url}?q=\"{address}\"".format(
+        '{base_url}?q="{address}"'.format(
             base_url=GEOCODE_API_URL, address=organization_address
         )
     )
@@ -13,5 +14,5 @@ def getGeocodeFromAddress(organization_address):
 
     if len(response_json) == 0:
         raise Exception("Failed to get coordinates from Geocode API")
-    
+
     return [float(response_json[0]["lat"]), float(response_json[0]["lon"])]

--- a/backend/tests/graphql/mock_test_data.py
+++ b/backend/tests/graphql/mock_test_data.py
@@ -1,9 +1,9 @@
 MOCK_INFO1_SNAKE = {
     "email": "test1@organization.com",
-    "organization_address": "123 Anywhere Street",
+    "organization_address": "255 King St N",
     "organization_name": "Test1 Org",
     "organization_desc": "Testing123",
-    "organization_coordinates": [12.345, 67.890],
+    "organization_coordinates": [43.477876300000005, -80.52565465],
     "role": "ASP",
     "role_info": {
         "asp_info": {
@@ -25,10 +25,10 @@ MOCK_INFO1_SNAKE = {
 
 MOCK_INFO1_CAMEL = {
     "email": "test1@organization.com",
-    "organizationAddress": "123 Anywhere Street",
+    "organizationAddress": "255 King St N",
     "organizationName": "Test1 Org",
     "organizationDesc": "Testing123",
-    "organizationCoordinates": [12.345, 67.890],
+    "organizationCoordinates": [43.477876300000005, -80.52565465],
     "role": "ASP",
     "roleInfo": {
         "aspInfo": {
@@ -50,10 +50,10 @@ MOCK_INFO1_CAMEL = {
 
 MOCK_INFO2_SNAKE = {
     "email": "test2@organization.com",
-    "organization_address": "456 Anywhere Street",
+    "organization_address": "370 Highland Rd W",
     "organization_name": "Test2 Org",
     "organization_desc": "Testing123",
-    "organization_coordinates": [12.345, 67.890],
+    "organization_coordinates": [43.4384664, -80.5118701],
     "role": "Donor",
     "role_info": {
         "asp_info": None,
@@ -76,10 +76,10 @@ MOCK_INFO2_SNAKE = {
 
 MOCK_INFO2_CAMEL = {
     "email": "test2@organization.com",
-    "organizationAddress": "456 Anywhere Street",
+    "organizationAddress": "370 Highland Rd W",
     "organizationName": "Test2 Org",
     "organizationDesc": "Testing123",
-    "organizationCoordinates": [12.345, 67.890],
+    "organizationCoordinates": [43.4384664, -80.5118701],
     "role": "Donor",
     "roleInfo": {
         "aspInfo": None,
@@ -102,10 +102,10 @@ MOCK_INFO2_CAMEL = {
 
 MOCK_INFO3_SNAKE = {
     "email": "test3@organization.com",
-    "organization_address": "789 Anywhere Street",
+    "organization_address": "170 University Ave W",
     "organization_name": "Test3 Org",
     "organization_desc": "Testing 123",
-    "organization_coordinates": [12.345, 67.890],
+    "organization_coordinates": [43.472995850000004, -80.5373252901463],
     "role": "Admin",
     "role_info": None,
     "primary_contact": {
@@ -122,10 +122,10 @@ MOCK_INFO3_SNAKE = {
 
 MOCK_INFO3_CAMEL = {
     "email": "test3@organization.com",
-    "organizationAddress": "789 Anywhere Street",
+    "organizationAddress": "170 University Ave W",
     "organizationName": "Test3 Org",
     "organizationDesc": "Testing 123",
-    "organizationCoordinates": [12.345, 67.890],
+    "organizationCoordinates": [43.472995850000004, -80.5373252901463],
     "role": "Admin",
     "roleInfo": None,
     "primaryContact": {

--- a/backend/tests/graphql/mock_test_data.py
+++ b/backend/tests/graphql/mock_test_data.py
@@ -3,6 +3,7 @@ MOCK_INFO1_SNAKE = {
     "organization_address": "123 Anywhere Street",
     "organization_name": "Test1 Org",
     "organization_desc": "Testing123",
+    "organization_coordinates": [12.345, 67.890],
     "role": "ASP",
     "role_info": {
         "asp_info": {
@@ -27,6 +28,7 @@ MOCK_INFO1_CAMEL = {
     "organizationAddress": "123 Anywhere Street",
     "organizationName": "Test1 Org",
     "organizationDesc": "Testing123",
+    "organizationCoordinates": [12.345, 67.890],
     "role": "ASP",
     "roleInfo": {
         "aspInfo": {
@@ -51,6 +53,7 @@ MOCK_INFO2_SNAKE = {
     "organization_address": "456 Anywhere Street",
     "organization_name": "Test2 Org",
     "organization_desc": "Testing123",
+    "organization_coordinates": [12.345, 67.890],
     "role": "Donor",
     "role_info": {
         "asp_info": None,
@@ -76,6 +79,7 @@ MOCK_INFO2_CAMEL = {
     "organizationAddress": "456 Anywhere Street",
     "organizationName": "Test2 Org",
     "organizationDesc": "Testing123",
+    "organizationCoordinates": [12.345, 67.890],
     "role": "Donor",
     "roleInfo": {
         "aspInfo": None,
@@ -101,6 +105,7 @@ MOCK_INFO3_SNAKE = {
     "organization_address": "789 Anywhere Street",
     "organization_name": "Test3 Org",
     "organization_desc": "Testing 123",
+    "organization_coordinates": [12.345, 67.890],
     "role": "Admin",
     "role_info": None,
     "primary_contact": {
@@ -120,6 +125,7 @@ MOCK_INFO3_CAMEL = {
     "organizationAddress": "789 Anywhere Street",
     "organizationName": "Test3 Org",
     "organizationDesc": "Testing 123",
+    "organizationCoordinates": [12.345, 67.890],
     "role": "Admin",
     "roleInfo": None,
     "primaryContact": {

--- a/backend/tests/graphql/test_all_user_mutations.py
+++ b/backend/tests/graphql/test_all_user_mutations.py
@@ -21,10 +21,9 @@ def test_update_user_by_id(user_setup, mocker):
                 id: "{str(user_1.id)}",
                 userInfo: {{
                     email: "test4@organization.com",
-                    organizationAddress: "789 Anywhere Street",
+                    organizationAddress: "170 University Ave W",
                     organizationName: "Test3 Org",
                     organizationDesc: "Testing 123",
-                    organizationCoordinates: [12.345, 67.890],
                     role: "Admin",
                     primaryContact: {{
                         name: "Anon ymous",
@@ -94,10 +93,9 @@ def test_update_user_by_id(user_setup, mocker):
                 id: "{str(user_1.id)}",
                 userInfo: {{
                     email: "test1@organization.com",
-                    organizationAddress: "123 Anywhere Street",
+                    organizationAddress: "255 King St N",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing123",
-                    organizationCoordinates: [12.345, 67.890]
                     role: "ASP",
                     roleInfo: {{
                        aspInfo: {{
@@ -180,10 +178,10 @@ def test_number_of_kids_cant_be_set_negative(user_setup, mocker):
                 id: "{str(user_1.id)}",
                 userInfo: {{
                     email: "test1@organization.com",
-                    organizationAddress: "123 Anywhere Street",
+                    organizationAddress: "255 King St N",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing123",
-                    organizationCoordinates: [12.345, 67.890]
+                    organizationCoordinates: [43.472995850000004, -80.5373252901463]
                     role: "ASP",
                     roleInfo: {{
                        aspInfo: {{

--- a/backend/tests/graphql/test_all_user_mutations.py
+++ b/backend/tests/graphql/test_all_user_mutations.py
@@ -24,6 +24,7 @@ def test_update_user_by_id(user_setup, mocker):
                     organizationAddress: "789 Anywhere Street",
                     organizationName: "Test3 Org",
                     organizationDesc: "Testing 123",
+                    organizationCoordinates: [12.345, 67.890],
                     role: "Admin",
                     primaryContact: {{
                         name: "Anon ymous",
@@ -52,6 +53,7 @@ def test_update_user_by_id(user_setup, mocker):
                         organizationAddress
                         organizationName
                         organizationDesc
+                        organizationCoordinates
                         role
                          roleInfo {{
                             aspInfo {{
@@ -95,6 +97,7 @@ def test_update_user_by_id(user_setup, mocker):
                     organizationAddress: "123 Anywhere Street",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing123",
+                    organizationCoordinates: [12.345, 67.890]
                     role: "ASP",
                     roleInfo: {{
                        aspInfo: {{
@@ -129,6 +132,7 @@ def test_update_user_by_id(user_setup, mocker):
                         organizationAddress
                         organizationName
                         organizationDesc
+                        organizationCoordinates
                         role
                         roleInfo {{
                             aspInfo {{
@@ -179,6 +183,7 @@ def test_number_of_kids_cant_be_set_negative(user_setup, mocker):
                     organizationAddress: "123 Anywhere Street",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing123",
+                    organizationCoordinates: [12.345, 67.890]
                     role: "ASP",
                     roleInfo: {{
                        aspInfo: {{
@@ -213,6 +218,7 @@ def test_number_of_kids_cant_be_set_negative(user_setup, mocker):
                         organizationAddress
                         organizationName
                         organizationDesc
+                        organizationCoordinates
                         role
                          roleInfo {{
                             aspInfo {{

--- a/backend/tests/graphql/test_all_user_mutations.py
+++ b/backend/tests/graphql/test_all_user_mutations.py
@@ -181,7 +181,6 @@ def test_number_of_kids_cant_be_set_negative(user_setup, mocker):
                     organizationAddress: "255 King St N",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing123",
-                    organizationCoordinates: [43.472995850000004, -80.5373252901463]
                     role: "ASP",
                     roleInfo: {{
                        aspInfo: {{

--- a/backend/tests/graphql/test_all_user_queries.py
+++ b/backend/tests/graphql/test_all_user_queries.py
@@ -17,6 +17,7 @@ def test_all_users(user_setup):
                     organizationAddress
                     organizationName
                     organizationDesc
+                    organizationCoordinates
                     role
                     roleInfo {
                         aspInfo {
@@ -67,6 +68,7 @@ def test_all_users_filter_by_role(user_setup):
                 organizationAddress
                 organizationName
                 organizationDesc
+                organizationCoordinates
                 role
                 roleInfo {
                     aspInfo {
@@ -109,6 +111,7 @@ def test_get_user_by_id(user_setup):
                     organizationAddress
                     organizationName
                     organizationDesc
+                    organizationCoordinates
                     role
                     roleInfo {{
                         aspInfo {{

--- a/backend/tests/graphql/test_onboarding_request.py
+++ b/backend/tests/graphql/test_onboarding_request.py
@@ -16,9 +16,6 @@ def test_create_onboarding_request():
                                 organizationAddress: "170 University Ave W",
                                 organizationName: "Test3 Org",
                                 organizationDesc: "Testing 123",
-                                organizationCoordinates: [
-                                    43.472995850000004, -80.5373252901463
-                                ],
                                 role: "Admin",
                                 primaryContact: {
                                     name: "Anon ymous",
@@ -95,7 +92,6 @@ def test_create_onboarding_request_with_existing_email_errors():
                     organizationAddress: "255 King St N",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing 123",
-                    organizationCoordinates: [43.477876300000005, -80.52565465],
                     role: "ASP",
                     roleInfo: {{
                         aspInfo: {{

--- a/backend/tests/graphql/test_onboarding_request.py
+++ b/backend/tests/graphql/test_onboarding_request.py
@@ -16,7 +16,9 @@ def test_create_onboarding_request():
                                 organizationAddress: "170 University Ave W",
                                 organizationName: "Test3 Org",
                                 organizationDesc: "Testing 123",
-                                organizationCoordinates: [43.472995850000004, -80.5373252901463],
+                                organizationCoordinates: [
+                                    43.472995850000004, -80.5373252901463
+                                ],
                                 role: "Admin",
                                 primaryContact: {
                                     name: "Anon ymous",

--- a/backend/tests/graphql/test_onboarding_request.py
+++ b/backend/tests/graphql/test_onboarding_request.py
@@ -13,10 +13,10 @@ def test_create_onboarding_request():
                         createOnboardingRequest (
                             userInfo: {
                                 email: "test3@organization.com",
-                                organizationAddress: "789 Anywhere Street",
+                                organizationAddress: "170 University Ave W",
                                 organizationName: "Test3 Org",
                                 organizationDesc: "Testing 123",
-                                organizationCoordinates: [12.345, 67.890],
+                                organizationCoordinates: [43.472995850000004, -80.5373252901463],
                                 role: "Admin",
                                 primaryContact: {
                                     name: "Anon ymous",
@@ -90,10 +90,10 @@ def test_create_onboarding_request_with_existing_email_errors():
             createOnboardingRequest (
                 userInfo: {{
                     email: "test1@organization.com",
-                    organizationAddress: "123 Anywhere Street",
+                    organizationAddress: "255 King St N",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing 123",
-                    organizationCoordinates: [12.345, 67.890],
+                    organizationCoordinates: [43.477876300000005, -80.52565465],
                     role: "ASP",
                     roleInfo: {{
                         aspInfo: {{

--- a/backend/tests/graphql/test_onboarding_request.py
+++ b/backend/tests/graphql/test_onboarding_request.py
@@ -16,6 +16,7 @@ def test_create_onboarding_request():
                                 organizationAddress: "789 Anywhere Street",
                                 organizationName: "Test3 Org",
                                 organizationDesc: "Testing 123",
+                                organizationCoordinates: [12.345, 67.890],
                                 role: "Admin",
                                 primaryContact: {
                                     name: "Anon ymous",
@@ -44,6 +45,7 @@ def test_create_onboarding_request():
                                     organizationAddress
                                     organizationName
                                     organizationDesc
+                                    organizationCoordinates
                                     role
                                     roleInfo {
                                         aspInfo {
@@ -91,6 +93,7 @@ def test_create_onboarding_request_with_existing_email_errors():
                     organizationAddress: "123 Anywhere Street",
                     organizationName: "Test1 Org",
                     organizationDesc: "Testing 123",
+                    organizationCoordinates: [12.345, 67.890],
                     role: "ASP",
                     roleInfo: {{
                         aspInfo: {{
@@ -125,6 +128,7 @@ def test_create_onboarding_request_with_existing_email_errors():
                         organizationAddress
                         organizationName
                         organizationDesc
+                        organizationCoordinates
                         role
                         roleInfo {{
                             aspInfo {{
@@ -169,6 +173,7 @@ def test_get_all_requests(onboarding_request_setup):
                         organizationAddress
                         organizationName
                         organizationDesc
+                        organizationCoordinates
                         role
                         roleInfo {
                             aspInfo {
@@ -220,6 +225,7 @@ def test_filter_requests_by_role(onboarding_request_setup):
                         organizationAddress
                         organizationName
                         organizationDesc
+                        organizationCoordinates
                         role
                         roleInfo {
                             aspInfo {
@@ -266,6 +272,7 @@ def test_filter_requests_by_status(onboarding_request_setup):
                         organizationAddress
                         organizationName
                         organizationDesc
+                        organizationCoordinates
                         role
                         roleInfo {
                             aspInfo {
@@ -312,6 +319,7 @@ def test_get_requests_by_id(onboarding_request_setup):
                     organizationAddress
                     organizationName
                     organizationDesc
+                    organizationCoordinates
                     role
                     roleInfo {{
                         aspInfo {{

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -14,7 +14,6 @@ test_user_info = {
     "organization_address": "123 Waterloo, ON",
     "organization_name": "Feeding Canadian Kids",
     "organization_desc": "Testing123",
-    "organization_coordinates": [12.345, 67.890],
     "role": "Donor",
     "role_info": {
         "asp_info": None,
@@ -59,10 +58,6 @@ def test_create_onboarding_request():
     )
     assert (
         onboarding_request.info.organization_desc == test_user_info["organization_desc"]
-    )
-    assert (
-        onboarding_request.info.organization_coordinates
-        == test_user_info["organization_coordinates"]
     )
     assert onboarding_request.info.role == test_user_info["role"]
     assert (

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -61,7 +61,8 @@ def test_create_onboarding_request():
         onboarding_request.info.organization_desc == test_user_info["organization_desc"]
     )
     assert (
-        onboarding_request.info.organization_coordinates == test_user_info["organization_coordinates"]
+        onboarding_request.info.organization_coordinates
+        == test_user_info["organization_coordinates"]
     )
     assert onboarding_request.info.role == test_user_info["role"]
     assert (

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -14,6 +14,7 @@ test_user_info = {
     "organization_address": "123 Waterloo, ON",
     "organization_name": "Feeding Canadian Kids",
     "organization_desc": "Testing123",
+    "organization_coordinates": [12.345, 67.890],
     "role": "Donor",
     "role_info": {
         "asp_info": None,
@@ -58,6 +59,9 @@ def test_create_onboarding_request():
     )
     assert (
         onboarding_request.info.organization_desc == test_user_info["organization_desc"]
+    )
+    assert (
+        onboarding_request.info.organization_coordinates == test_user_info["organization_coordinates"]
     )
     assert onboarding_request.info.role == test_user_info["role"]
     assert (


### PR DESCRIPTION
## Notion Ticket Link
<!-- Please replace with your ticket's URL -->
https://www.notion.so/uwblueprintexecs/Add-location-to-users-BE-3282fb1c96e34c70bd01447c33ec911f


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation Description
* Added organization_coordinates field to user, storing latitude and longitude of given address as a GeoPoint (2D array)
* Utilized Geocode API to find proper coordinates of organization_address and update organization_coordinates field accordingly (triggered when creating a user or updating a user)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps To Test
1. Check that when creating or updating a user, organization_coordinates are appropriately updated based on address


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What Should Reviewers Focus On?
* Confirm creating a user works as intended, I was able to test updating a user through unit tests and GraphQL queries but found it more difficult to test creating a user


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have added tests for my changes
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
