### PR TITLE
Remove number of kids on Settings if user is Meal Donor

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -40,6 +40,7 @@ import {
   trimWhiteSpace,
 } from "../utils/ValidationUtils";
 import useGetOnsiteContacts from "../utils/useGetOnsiteContacts";
+import useIsMealDonor from "../utils/useIsMealDonor";
 import useIsWebView from "../utils/useIsWebView";
 
 const PLACEHOLDER_WEB_EXAMPLE_FULL_NAME = "Jane Doe";
@@ -160,13 +161,13 @@ const DELETE_ONSITE_CONTACT = gql`
 `;
 
 const Settings = (): React.ReactElement => {
-  // Assumption: user has the roleInfo: ASPInfo
-
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
 
   const [userInfo, setUserInfo] = useState<UserInfo>(
     authenticatedUser?.info || null,
   );
+
+  const isMealDonor = useIsMealDonor();
 
   const [primaryContact, setPrimaryContact] = useState<Contact>(
     userInfo?.primaryContact || {
@@ -480,20 +481,22 @@ const Settings = (): React.ReactElement => {
             />
           </FormControl>
         </Flex>
-        <Flex flexDir="column" w="200px">
-          <FormControl
-            isRequired
-            isInvalid={attemptedSubmit && !isNonNegativeInt(numKids)}
-          >
-            <FormLabel variant="form-label-bold">Number of kids</FormLabel>
-            <Input
-              type="number"
-              value={numKids}
-              placeholder={PLACEHOLDER_WEB_EXAMPLE_NUMBER_OF_KIDS}
-              onChange={(e) => setNumKids(e.target.value)}
-            />
-          </FormControl>
-        </Flex>
+        {isMealDonor ? null : (
+          <Flex flexDir="column" w="200px">
+            <FormControl
+              isRequired
+              isInvalid={attemptedSubmit && !isNonNegativeInt(numKids)}
+            >
+              <FormLabel variant="form-label-bold">Number of kids</FormLabel>
+              <Input
+                type="number"
+                value={numKids}
+                placeholder={PLACEHOLDER_WEB_EXAMPLE_NUMBER_OF_KIDS}
+                onChange={(e) => setNumKids(e.target.value)}
+              />
+            </FormControl>
+          </Flex>
+        )}
         <Flex flexDir="column" w="350px">
           <FormControl
             isRequired
@@ -547,18 +550,20 @@ const Settings = (): React.ReactElement => {
               onChange={(e) => setOrganizationName(e.target.value)}
             />
           </FormControl>
-          <FormControl
-            isRequired
-            isInvalid={attemptedSubmit && !isNonNegativeInt(numKids)}
-          >
-            <Input
-              variant="mobile-outline"
-              type="number"
-              value={numKids}
-              placeholder={PLACEHOLDER_MOBILE_EXAMPLE_NUMBER_OF_KIDS}
-              onChange={(e) => setNumKids(e.target.value)}
-            />
-          </FormControl>
+          {isMealDonor ? null : (
+            <FormControl
+              isRequired
+              isInvalid={attemptedSubmit && !isNonNegativeInt(numKids)}
+            >
+              <Input
+                variant="mobile-outline"
+                type="number"
+                value={numKids}
+                placeholder={PLACEHOLDER_MOBILE_EXAMPLE_NUMBER_OF_KIDS}
+                onChange={(e) => setNumKids(e.target.value)}
+              />
+            </FormControl>
+          )}
           <FormControl
             isRequired
             isInvalid={attemptedSubmit && organizationAddress === ""}


### PR DESCRIPTION
Since only ASPs have kids, Meal Donors should not be able to see a "Number of kids" input

## Notion Ticket Link
<!-- Please replace with your ticket's URL -->
[Remove number of kids on the user settings page if the user is a meal donor](https://www.notion.so/uwblueprintexecs/Remove-number-of-kids-on-the-user-settings-page-if-the-user-is-a-meal-donor-d3b45f2fe5d9440985b4455cb2a8f080?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation Description
* Added some conditions using ternary operators. Checked if user is Meal Donor using useIsMealDonor hook.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps To Test
1. Log in as ASP and check to see if "Number of Kids" input field exists
2. Log in as Meal Donor and check to see if "Number of Kids" input field does not exist

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What Should Reviewers Focus On?
*


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [X] I have added tests for my changes
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
