### PR TITLE
Add mobile view for upcoming commitments

### DIFF
--- a/frontend/src/pages/UpcomingPage.tsx
+++ b/frontend/src/pages/UpcomingPage.tsx
@@ -195,7 +195,7 @@ export const UpcomingCard = ({ event }: { event: UpcomingEvent }) => {
       <Card padding={3} variant="outline">
         <Flex
           direction={["column", "row"]}
-          justifyContent="space-between"
+          justifyContent="space-around"
           alignItems="center"
         >
           <VStack padding={10}>

--- a/frontend/src/pages/UpcomingPage.tsx
+++ b/frontend/src/pages/UpcomingPage.tsx
@@ -176,7 +176,7 @@ export const UpcomingCard = ({ event }: { event: UpcomingEvent }) => {
   return (
     <div
       style={{
-        width: "55%",
+        maxWidth: "800px",
       }}
     >
       {currentlyEditingMealRequestId ? (
@@ -193,7 +193,7 @@ export const UpcomingCard = ({ event }: { event: UpcomingEvent }) => {
         ""
       )}
       <Card padding={3} variant="outline">
-        <HStack dir="row">
+        <Flex direction={["column", "row"]} justifyContent="space-between">
           <VStack padding={10}>
             <Text fontSize="md">
               {
@@ -274,7 +274,7 @@ export const UpcomingCard = ({ event }: { event: UpcomingEvent }) => {
               </VStack>
             </HStack>
           </VStack>
-        </HStack>
+        </Flex>
       </Card>
     </div>
   );
@@ -461,15 +461,6 @@ const UpcomingPage = (): React.ReactElement => {
         {tabSelected === 0 ? "Upcoming" : "Completed"} Donations
       </Text>
 
-      <Text
-        fontFamily="Inter"
-        fontWeight="400"
-        fontSize={["12px", "16px"]}
-        pb="10px"
-      >
-        My {tabSelected === 0 ? "upcoming" : "completed"} meal donations
-      </Text>
-
       {
         // Not entirely sure why this was here...
         /* <Flex
@@ -547,13 +538,11 @@ const UpcomingPage = (): React.ReactElement => {
             )}
             {!getUpcomingMealRequestsLoading && (
               <>
-                {isWebView && (
-                  <Stack direction="column">
-                    {upcomingMealRequests?.map((event) => (
-                      <UpcomingCard event={event} key={event.id} />
-                    ))}
-                  </Stack>
-                )}
+                <Stack direction="column">
+                  {upcomingMealRequests?.map((event) => (
+                    <UpcomingCard event={event} key={event.id} />
+                  ))}
+                </Stack>
                 <HStack>
                   <Button
                     leftIcon={<ChevronLeftIcon />}

--- a/frontend/src/pages/UpcomingPage.tsx
+++ b/frontend/src/pages/UpcomingPage.tsx
@@ -193,7 +193,11 @@ export const UpcomingCard = ({ event }: { event: UpcomingEvent }) => {
         ""
       )}
       <Card padding={3} variant="outline">
-        <Flex direction={["column", "row"]} justifyContent="space-between">
+        <Flex
+          direction={["column", "row"]}
+          justifyContent="space-between"
+          alignItems="center"
+        >
           <VStack padding={10}>
             <Text fontSize="md">
               {


### PR DESCRIPTION
## Notion Ticket Link
<!-- Please replace with your ticket's URL -->
[Replace with Ticket URL](https://www.notion.so/uwblueprintexecs/Dev-e3112e78136f49b4b042e9a0d9df9723?pvs=4#659939ff45cd470a81d5ec2cda7ed52a)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation Description
* Make the mobile view for upcoming commitments work
* Remove the redundant "my upcoming meal donations" text


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps To Test
1. **Look at the upcoming meal commitments table (meal donor dashboard) at all sizes

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have added tests for my changes
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
