### PR TITLE
Fix validation for edit meal request modal

### DIFF
--- a/frontend/src/pages/EditMealRequestForm.tsx
+++ b/frontend/src/pages/EditMealRequestForm.tsx
@@ -290,13 +290,6 @@ const EditMealRequestForm = ({
       }
     }
 
-    if (!isEditDonation) {
-      if (deliveryInstructions === "") {
-        setAttemptedSubmit(true);
-        return false;
-      }
-    }
-
     setAttemptedSubmit(false);
     return true;
   };
@@ -527,16 +520,17 @@ const EditMealRequestForm = ({
               </Text>
 
               {!isUpcoming ? (
-                <FormControl mt={3} mb={6} isRequired>
+                <FormControl
+                  mt={3}
+                  mb={6}
+                  isRequired
+                  isInvalid={attemptedSubmit && numberOfMeals <= 0}
+                >
                   <FormLabel
                     variant={{
                       base: "mobile-form-label-bold",
                       md: "form-label-bold",
                     }}
-
-                    // TODO: Hook this up to a state variable
-                    // TODO: Setup correct validation for this
-                    // isInvalid={attemptedSubmit && }
                   >
                     Number of meals
                   </FormLabel>
@@ -552,7 +546,7 @@ const EditMealRequestForm = ({
               ) : null}
 
               {!isUpcoming ? (
-                <FormControl mt={3} mb={6} isRequired>
+                <FormControl mt={3} mb={6}>
                   <FormLabel
                     variant={{
                       base: "mobile-form-label-bold",
@@ -569,14 +563,12 @@ const EditMealRequestForm = ({
                 </FormControl>
               ) : null}
 
-              <FormControl mt={3} mb={6} isRequired>
+              <FormControl mt={3} mb={6}>
                 <FormLabel
                   variant={{
                     base: "mobile-form-label-bold",
                     md: "form-label-bold",
                   }}
-                  // TODO: Setup correct validation for this
-                  // isInvalid={attemptedSubmit && }
                 >
                   Delivery Notes
                 </FormLabel>


### PR DESCRIPTION
## Notion Ticket Link
<!-- Please replace with your ticket's URL -->
[Replace with Ticket URL](https://www.notion.so/uwblueprintexecs/Dev-e3112e78136f49b4b042e9a0d9df9723?pvs=4#659939ff45cd470a81d5ec2cda7ed52a)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation Description
* Adds validation (and red highlights if errors) on the edit meal request modal


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have added tests for my changes
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
